### PR TITLE
Editable Disclaimers

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -27,6 +27,42 @@
         <hr />
         <section>
           <h2>
+            <a data-toggle="collapse" href="#newDisclaimer" role="button" aria-expanded="false" aria-controls="newDisclaimer">New Disclaimer</a>
+          </h2>
+          <div class="form-row collapse" id="newDisclaimer">
+              <div class="col">
+                  <input class="form-control" ng-model="newDisclaimerName" placeholder="Disclaimer Name" />
+              </div>
+              <div class="col-6">
+                  <input class="form-control" ng-model="newDisclaimerText" placeholder="Disclaimer Text" />
+              </div>
+              <div class="col">
+                  <button class="btn btn-success" ng-click="addDisclaimer(newDisclaimerName, newDisclaimerText)">Create Disclaimer</button>
+              </div>
+          </div>
+        </section>
+        <hr />
+        <section>
+            <h2>
+              <a data-toggle="collapse" href="#manageDisclaimers" role="button" aria-expanded="false" aria-controls="manageDisclaimers">Manage Disclaimers</a>
+            </h2>
+            <div class="form-row collapse" id="manageDisclaimers">
+                <div class="col">
+                    <select class="form-control" ng-model="selectedDisclaimer" ng-options="disclaimer as name for (name, disclaimer) in disclaimers">
+                        <option></option>
+                    </select>
+                </div>
+                <div class="col-6">
+                    <input class="form-control" ng-model="selectedDisclaimer.text" placeholder="Disclaimer Text">
+                </div>
+                <div class="col">
+                    <button class="btn btn-danger" ng-click="deleteDisclaimer(selectedDisclaimer)">Delete Disclaimer</button>
+                </div>
+            </div>
+          </section>
+        <hr />
+        <section>
+          <h2>
             <a data-toggle="collapse" href="#newAlert" role="button" aria-expanded="false" aria-controls="newAlert">New Alert</a>
           </h2>
           <div class="form-row collapse" id="newAlert">
@@ -34,7 +70,7 @@
                   <input class="form-control" ng-model="newAlertName" placeholder="Alert Name" />
               </div>
               <div class="col">
-                  <input class="form-control " ng-model="newAlertText" placeholder="Alert Text" />
+                  <input class="form-control" ng-model="newAlertText" placeholder="Alert Text" />
               </div>
               <div class="col">
                   <select class="form-control" ng-model="newAlertClass">
@@ -56,12 +92,12 @@
             </h2>
             <div class="form-row collapse" id="manageAlerts">
                 <div class="col">
-                    <select class="form-control " ng-model="selectedAlert" ng-options="alert as name for (name, alert) in alerts">
+                    <select class="form-control" ng-model="selectedAlert" ng-options="alert as name for (name, alert) in alerts">
                         <option></option>
                     </select>
                 </div>
                 <div class="col">
-                    <input class="form-control" ng-model="selectedAlert.text" size="35" placeholder="Alert Text">
+                    <input class="form-control" ng-model="selectedAlert.text" placeholder="Alert Text">
                 </div>
                 <div class="col">
                     <select class="form-control" ng-model="selectedAlert.class">
@@ -112,7 +148,7 @@
             <div class="row">
               <div class="form-group col">
                 <label>Dmg Type</label>
-                <input class="form-control "ng-model="newPrimaryDmg" />
+                <input class="form-control"ng-model="newPrimaryDmg" />
               </div>
               <div class="form-group col">
                 <label>Wep Type</label>

--- a/index.html
+++ b/index.html
@@ -63,26 +63,22 @@
         </div>
     </nav>
 
-    <div class="parallax text-white py-5" id="page-top">
-        <div class="container pt-5">
-            <p class="lead">
-                This is a partially subjective tier list, however constructive criticism is always encouraged and appreciated.
-                <a href="https://www.reddit.com/r/Warframe/comments/3p6wgu/updated_pve_tier_list_for_1771/cw3qzy8">Before you freak out about a weapon's tier, read this disclaimer by /u/4G3NT_0R4NGE3.</a> Nevertheless, this guide is intended to get a
-                general sense of the equipment in the game.
-            </p>
-            <p class="lead">
-                <u>
-                Ordering of items is only somewhat meaningful, positions can be considered +/- 5 of each other.
-              </u>
-            </p>
-            <p class="d-block d-md-none lead">
-                If you're on mobile, try Landscape Mode!
-            </p>
-            <p class="text-right">
-                <a class="btn btn-primary btn-discord" href="https://discord.gg/Cq3jW27">
-                <i class="fab fa-discord"></i> Join The Discussion
-              </a>
-            </p>
+    <div class="card mt-5">
+        <div class="container">
+            <div class="card-body">
+                <div class="lead" ng-repeat="disclaimer in disclaimers">
+                  <p ng-bind-html="disclaimer.text | unsafe">
+                  </p>
+                </div>
+                <p class="d-block d-md-none lead">
+                    If you're on mobile, try Landscape Mode!
+                </p>
+                <p>
+                    <a class="btn btn-primary btn-discord" href="https://discord.gg/Cq3jW27">
+                        <i class="fab fa-discord"></i> Join The Discussion
+                    </a>
+                </p>
+            </div>
         </div>
     </div>
 
@@ -102,10 +98,10 @@
                         </div>
                     </div>
                 </form>
-                <nav >
+                <nav class="mb-2">
                     <ul class="nav nav-tabs" id="tabs" role="tablist">
                         <li class="nav-item" id="{(category)}tab" ng-repeat="category in categories">
-                            <a class="nav-link" data-toggle="tab" href="#{(category)}">{(category)}</a>
+                            <a class="nav-link" data-toggle="tab" href="#{(category)}" id="{(category)}link">{(category)}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" data-toggle="tab" href="#Sentweps">Sentinel Weapons</a>
@@ -509,6 +505,8 @@
 
         $(document).ready(function() {
             $('#Primariestab').addClass("active");
+            $("#Primarieslink").addClass("active")
+            $("#Primarieslink").addClass("show")
         });
     </script>
 </body>

--- a/js/editor.js
+++ b/js/editor.js
@@ -20,6 +20,8 @@ app.controller("EditorController", function EditorController($scope, $http) {
 
             $scope.alerts = db.alerts;
 
+            $scope.disclaimers = db.disclaimers;
+
             $scope.Primaries = $.map(db.Primaries, function (element) {
                 return element;
             });
@@ -145,7 +147,7 @@ app.controller("EditorController", function EditorController($scope, $http) {
                 text: newAlertText
             };
 
-        alert('Added alert: ' + db.alerts[newAlertName]);
+        alert('Added alert: ' + newAlertName);
     };
 
     $scope.deleteAlert = function (toDelete) {
@@ -153,6 +155,23 @@ app.controller("EditorController", function EditorController($scope, $http) {
             (element) => {
                 if (db.alerts[element].text === toDelete.text)
                     delete db.alerts[element];
+            });
+    };
+
+    $scope.addDisclaimer = function (newDisclaimerName, newDisclaimerText) {
+        db.disclaimers[newDisclaimerName] =
+            {
+                text: newDisclaimerText
+            };
+
+        alert('Added disclaimer: ' + newDisclaimerName);
+    };
+
+    $scope.deleteDisclaimer = function (toDelete) {
+        Object.keys(db.disclaimers).forEach(
+            (element) => {
+                if (db.disclaimers[element].text === toDelete.text)
+                    delete db.disclaimers[element];
             });
     };
 

--- a/js/main.js
+++ b/js/main.js
@@ -14,10 +14,13 @@ app.config([
     }
 ]);
 
+// This is used for the unsafe pipe to render HTML from the JSON file.
+
+app.filter('unsafe', function($sce) { return $sce.trustAsHtml; });
+
 app.controller("TierListController", function TierListController($scope, $http) {
 
     $scope.loading = true;
-
     $http({
         method: 'GET',
         url: './js/thelist.json'
@@ -27,6 +30,10 @@ app.controller("TierListController", function TierListController($scope, $http) 
         $scope.version = database.version;
 
         $scope.alerts = $.map(database.alerts, function (element) {
+            return element;
+        });
+
+        $scope.disclaimers = $.map(database.disclaimers, function (element) {
             return element;
         });
 

--- a/js/thelist.json
+++ b/js/thelist.json
@@ -1861,7 +1861,7 @@
       "type": "Hammer",
       "url": "http://warframe.wikia.com/wiki/Heliocor",
       "wepnotes": "High damage per hit, poor DPS, low attack speed. Gives one codex scan upon kill. ",
-      "rivenDisposition": 0.94    
+      "rivenDisposition": 0.94
     }
   },
   "Primaries": {
@@ -2835,7 +2835,7 @@
       "rank": 36,
       "tier": "Top",
       "type": "Beam"
-    }      
+    }
   },
   "Schools": {
     "Madurai": {
@@ -3720,7 +3720,7 @@
     "Contender": {
       "name": "Contender",
       "rank": 2
-    },	
+    },
     "Top": {
       "name": "Top",
       "rank": 1
@@ -3742,7 +3742,15 @@
     "hosting": {
       "class": "alert-success",
       "note_to_sakai": "you take this alert out after about 1 mo. October 26th",
-      "text": "Hosting costs will now be covered by Creators' Collective at https://creatorscollective.club."
+      "text": "Hosting costs will now be covered by Creators' Collective at http://creatorscollective.club."
+    }
+  },
+  "disclaimers":{
+    "general": {
+      "text": "This is a partially subjective tier list, however constructive criticism is always encouraged and appreciated.<a href='https://www.reddit.com/r/Warframe/comments/3p6wgu/updated_pve_tier_list_for_1771/cw3qzy8'>Before you freak out about a weapon's tier, read this disclaimer by /u/4G3NT_0R4NGE3.</a> Nevertheless, this guide is intended to get a general sense of the equipment in the game."
+    },
+    "ordering": {
+      "text": "<u>Ordering of items is only somewhat meaningful, positions can be considered +/- 5 of each other.</u>"
     }
   },
   "faq": {


### PR DESCRIPTION
In this fork, I make the "disclaimer" section editable.
- Cleans up the HTML code for the disclaimer section, removes image background (can be re-added)
- Adds Angular Pipe to "sanitize" html input
- Pipes information from "disclaimer" object in `thelist.json` to disclaimers, similar to alerts
- Adds GUI in editor page to allow adding and managing disclaimers
- A few minor adjustments to syntax elsewhere when  looking around - big one is that the Primaries tab is now auto-selected

Let me know what you think!